### PR TITLE
Reinstantes pygments to get syntax highlighting back

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 safe: true
 lsi: false
-highlighter: true
+pygments: true
 permalink: /:year/:title/


### PR DESCRIPTION
Sorry @omgmog, github pages only supports pygments atm (https://help.github.com/articles/page-build-failed-config-file-error/#highlighting-errors).