### PR TITLE
Remove PNGQuant

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,12 @@
   "description": "",
   "author": "",
   "version": "2.0.0",
-  "dependencies": {},
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-connect": "~0.9.0",
     "grunt-contrib-cssmin": "~0.10.0",
     "grunt-contrib-htmlmin": "~0.3.0",
-    "grunt-contrib-imagemin": "~0.9.3",
+    "grunt-contrib-imagemin": "^0.9.4",
     "grunt-contrib-less": "^1.0.0",
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-css-url-embed": "^1.5.1",
@@ -18,7 +17,6 @@
     "grunt-uncss": "~0.3.4",
     "imagemin-jpeg-recompress": "^4.1.0",
     "imagemin-mozjpeg": "^4.0.0",
-    "imagemin-pngquant": "^4.0.0",
     "load-grunt-tasks": "~0.6.0"
   }
 }


### PR DESCRIPTION
Fixes `grunt optimize` task. Related to https://github.com/gruntjs/grunt-contrib-imagemin/issues/285.