### PR TITLE
only show a single upcoming event

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -98,10 +98,9 @@
     }
     function populateUpcomingEvents(){
         if(upcomingEvents.length > 0){
-            $('#UpcomingEvents').empty();
-            for(var i=0;i<upcomingEvents.length;i++){
-                $('#UpcomingEvents').append(buildPost(upcomingEvents[i], true));
-            }
+            $('#UpcomingEvents')
+                .empty()
+                .append(buildPost(upcomingEvents[0], true));
         }
     }
     function populatePastEvents(){


### PR DESCRIPTION
We're going to have a bunch of events to add for summer of hacks - and I think it's going to get a bit confusing on the front page with May, June, July, March, Feb.

Moving past events to a different page would probably sort it - but I think this is an easier fix for now.