### PR TITLE
Remove WO logo from cycled images within JSOxford logo

### DIFF
--- a/welcome.html
+++ b/welcome.html
@@ -188,14 +188,6 @@
         opacity: 1;
         transform: translate(50px,50px) rotate(-360deg);
       }
-      .jo-wo {
-        opacity: 0;
-        transform: translate(50px, 50px) scale(2);
-      }
-      .jo-wo.on {
-        opacity: 1;
-        transform: translate(50px,50px) scale(2);
-      }
       .jo-unicorn {
         opacity: 0;
         transform: translate(50px, 50px);
@@ -228,7 +220,7 @@
 
     <script><![CDATA[
       var icons = [
-        '.jo-nodebot','.jo-github','.jo-grunt','.jo-html5', '.jo-gulp', '.jo-nodejs', '.jo-wo', '.jo-unicorn',
+        '.jo-nodebot','.jo-github','.jo-grunt','.jo-html5', '.jo-gulp', '.jo-nodejs', '.jo-unicorn',
         '.jo-handlebars'
         ];
       var waitTimeout = 5000;
@@ -275,37 +267,6 @@
       setTimeout(function(){
         showRandom();
       }, waitTimeout);
-
-      /*
-        White October Animation
-      */
-      setTimeout(function(){
-        var colours = [["#ED1E79","#9E005D","#ED1E79","#ED1E79","#ED1E79","#9E005D","#ED1E79","#ED1E79","#9E005D","#9E005D","#ED1E79","#9E005D","#9E005D","#ED1E79","#9E005D","#9E005D","#ED1E79","#ED1E79","#9E005D","#ED1E79","#ED1E79","#ED1E79","#ED1E79","#9E005D","#ED1E79","#ED1E79","#9E005D","#ED1E79"],["#00D1E2","#00E4EB","#00E4EB","#00DAE6","#00FFF8","#00F6F4","#00EDEF","#00F6F4","#00DAE6","#00FFF8","#00C8DD","#00EDEF","#00EDEF","#00C8DD","#00FFF8","#00DAE6","#00D1E2","#00EDEF","#00E4EB","#00DAE6","#00F6F4","#00FFF8","#00E4EB","#00F6F4","#00F6F4","#00FFF8","#00FFF8","#00EDEF"],["#7373E5","#8383E5","#7373E5","#6B6BDD","#8B8BEA","#8383E5","#8B8BEA","#9595EF","#7C7CE5","#9C9CF2","#6B6BDD","#7C7CE5","#7C7CE5","#6B6BDD","#8B8BEA","#6B6BDD","#7373E5","#8B8BEA","#7373E5","#7C7CE5","#9595EF","#9C9CF2","#8383E5","#8383E5","#7373E5","#7C7CE5","#7C7CE5","#6B6BDD"],["#F18600","#E95A00","#F18600","#F18600","#E22D00","#E95A00","#E22D00","#E22D00","#E95A00","#DB0000","#F18600","#E95A00","#F8B300","#FFE000","#F8B300","#F8B300","#FFE000","#FFE000","#F8B300","#FFE000","#FFE000","#FFE000","#FFE000","#F8B300","#F18600","#F18600","#E95A00","#F18600"],["#10A2AD","#10ADAD","#10A2AD","#10A2AD","#0DB2A2","#10ADAD","#0DB2A2","#0DB2A2","#10ADAD","#16BCA6","#10A2AD","#10ADAD","#1195AA","#1385A8","#1195AA","#1195AA","#1385A8","#1385A8","#1195AA","#1385A8","#1385A8","#1385A8","#1385A8","#1195AA","#10A2AD","#10A2AD","#10ADAD","#10A2AD"],["#DB0000","#E22D00","#E22D00","#E22D00","#F18600","#E95A00","#E95A00","#E95A00","#E22D00","#F18600","#DB0000","#E95A00","#E95A00","#DB0000","#F18600","#E22D00","#DB0000","#E95A00","#E22D00","#E22D00","#E95A00","#F18600","#E22D00","#E95A00","#E95A00","#F18600","#F18600","#E95A00"],["#00AAC6","#00CCDA","#26ACDC","#19A5D1","#26DEF9","#39CEFA","#00DDE4","#00EEEE","#00BBD0","#00FFF8","#0099BC","#30BDEB","#7384EE","#0099BC","#997DFE","#19A5D1","#208FC7","#7F70E9","#26ACDC","#4085D2","#AC6CFE","#BF5CFF","#5F7BDE","#868DFD","#5FAEFC","#739DFC","#4CBEFB","#33B2E6"],["#FF00FF","#CCCCCC","#FF00FF","#FF00FF","#FF00FF","#CCCCCC","#FF00FF","#FF00FF","#CCCCCC","#CCCCCC","#FF00FF","#CCCCCC","#CCCCCC","#FF00FF","#CCCCCC","#CCCCCC","#FF00FF","#FF00FF","#CCCCCC","#FF00FF","#FF00FF","#FF00FF","#FF00FF","#CCCCCC","#FF00FF","#FF00FF","#CCCCCC","#FF00FF"],["#000C52","#3A65EF","#8CDEF4","#8CDEF4","#8CDEF4","#8CDEF4","#000C52","#000C52","#3A65EF","#3A65EF","#000C52","#8CDEF4","#8CDEF4","#000C52","#3A65EF","#3A65EF","#000C52","#000C52","#3A65EF","#8CDEF4","#000C52","#8CDEF4","#8CDEF4","#8CDEF4","#000C52","#8CDEF4","#3A65EF","#000C52"]];
-
-        var polys = [].slice.call(document.querySelectorAll('.jo-wo polygon'),0);
-
-        polys.forEach(function(p, i){
-          p.style.transitionDelay = (i/30) + 's';
-        });
-
-        function showWo(x){
-          polys.forEach(function(p, i){
-            p.style.fill = colours[x][i];
-          });
-        }
-
-        function loop(){
-          for (var i = 0; i < colours.length; i++) {
-            setTimeout(showWo, (i+1) * 3000, i);
-          }
-          setTimeout(loop, i * 3000);
-        }
-        loop();
-
-      }, 1000);
-
-
-
     ]]></script>
 
     <!--yellow background-->


### PR DESCRIPTION
I'm not comfortable with having sponsor images within the JSOxford logo. We need to be grateful to our sponsors for their generosity, and make sure that we spread the word about them so they get value from the sponsorship, but I think it's important to be seen as our own organisation. There are already a fair number of people who think that JSOxford is a set of WO events, so I'm keen for us to make the distinction early and clearly. 

This PR just removes the WO logo from those cycled through in the JSOxford logo. We probably want to set aside a space somewhere on the welcome page to house the sponsor logos so they're more prominent (and more obviously sponsors), with a "Thanks" or something, but that can be covered in a subsequent PR.