### PR TITLE
Changed wording for upcoming events to 'are going'

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,7 +19,14 @@ layout: default
             <div class="eventInfo col-xs-3">
                 <span class="eventDate">{{ page.date | date: "%a %b %d"}} </span>
                 <span class="eventTime">{{ page.date | date: "%I:%M %p"}}</span>
-                <a href="{{ page.externalURL }}"><span class="attendees">{{page.attendees}}</span> went</a>
+                <a href="{{ page.externalURL }}">
+                    <span class="attendees">{{page.attendees}}</span>
+                    {% if page.status == 'upcoming' %}
+                        are going
+                    {% else %}
+                        went
+                    {% endif %}
+                </a>
             </div>
         {% endif %}
         {% if page.author != null %}

--- a/archive.html
+++ b/archive.html
@@ -26,7 +26,7 @@ title: Archive
                         <div class="eventInfo col-xs-3">
                             <span class="eventDate">{{ post.date | date: "%a %b %d"}} </span>
                             <span class="eventTime">{{ post.date | date: "%I:%M %p"}}</span>
-                            <a href="{{ post.externalURL }}"><span class="attendees">{{post.attendees}}</span> went</a>
+                            <a href="{{ post.externalURL }}"><span class="attendees">{{post.attendees}}</span> are going</a>
                         </div>
                     {% endif %}
                     {% if post.author != null %}

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ layout: default
                         <div class="eventInfo col-xs-3">
                             <span class="eventDate">{{ post.date | date: "%a %b %d"}} </span>
                             <span class="eventTime">{{ post.date | date: "%I:%M %p"}}</span>
-                            <a href="{{ post.externalURL }}"><span class="attendees">{{post.attendees}}</span> went</a>
+                            <a href="{{ post.externalURL }}"><span class="attendees">{{post.attendees}}</span> are going</a>
                         </div>
                     {% endif %}
                     {% if post.author != null %}


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/3384072/8766728/3fd6eb1c-2e3b-11e5-9e8f-bd2c6a78aa55.png)

After:
![image](https://cloud.githubusercontent.com/assets/3384072/8766735/75040d92-2e3b-11e5-968f-822e3d68dad2.png)
