### PR TITLE
Removed spacing around member photos

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -113,9 +113,16 @@ footer {
 }
 
 #MeetupMembers {
+  line-height: 0.7em;
+
   a {
     display: inline-block;
     margin-left: 10px;
+
+    &:last-of-type {
+      float: right;
+      line-height: 2.5em;
+    }
 
     &.memberThumbnail {
       margin: 0;


### PR DESCRIPTION
Before: 
![image](https://cloud.githubusercontent.com/assets/3384072/8766775/c30a6ff8-2e3c-11e5-8039-bf6a958e2d40.png)

After:
![image](https://cloud.githubusercontent.com/assets/3384072/8766776/cda6793e-2e3c-11e5-8a64-501c3f9de20b.png)
