### PR TITLE
Change default Grunt behavior to not generate meetup posts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -278,11 +278,11 @@ module.exports = function(grunt) {
     });
   });
 
-  grunt.registerTask('meetup', 'buildMeetupPosts');
-  grunt.registerTask('build', ['meetup', 'sprite-members','jekyll:build']);
+  grunt.registerTask('meetup', ['buildMeetupPosts','sprite-members']);
+  grunt.registerTask('build', ['jekyll:build']);
   grunt.registerTask('sprite-members', ['downloadmemberphotos','sprite', 'clean:members']);
   grunt.registerTask('optimize', ['cssmin','uncss','imagemin','uglify','htmlmin']);
-  grunt.registerTask('deploy', ['build','optimize','buildcontrol']);
+  grunt.registerTask('deploy', ['meetup', 'build','optimize','buildcontrol']);
   grunt.registerTask('default', ['build','jekyll:serve']);
 
 };


### PR DESCRIPTION
@spikeheap - Meetup posts/member sprite will now just be generated by Travis so when running locally there wont be any new untracked files created and the build wont be reliant on network.