### PR TITLE
Revert "Upgrade travis to use containers"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 branches:
   only:
     - develop


### PR DESCRIPTION
Reverts jsoxford/jsoxford.github.com#157. PhantomJS fails when run on containers.