### PR TITLE
Remove `imagemin` from optimise step

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -303,7 +303,7 @@ module.exports = function(grunt) {
   grunt.registerTask('meetup', ['buildMeetupPosts','sprite-members']);
   grunt.registerTask('build', ['jekyll:build']);
   grunt.registerTask('sprite-members', ['downloadmemberphotos','sprite', 'clean:members']);
-  grunt.registerTask('optimize', ['cssmin','uncss','imagemin','uglify','htmlmin']);
+  grunt.registerTask('optimize', ['cssmin','uncss','uglify','htmlmin']); // TODO: add 'imagemin' back
   grunt.registerTask('deploy', ['meetup', 'build','optimize','buildcontrol']);
   grunt.registerTask('default', ['build','jscs','jekyll:serve']);
 


### PR DESCRIPTION
This is the second time (in two meetups), that imagemin has thrown an error and stopped the build.

I say we remove it for now.  It's more important that the site is up to date for now.