### PR TITLE
Replace jsoxford slack with digitaloxford

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 :+1::+1::+1: JSOxford is entirely volunteer-run, so thanks for helping! :+1::+1::+1:
 
-If you're unsure of anything, have a question or want to find anything out, [come chat with us on Slack](https://jsoxford.slack.com) (Sign up [here](https://jsoxford.herokuapp.com)).
+If you're unsure of anything, have a question or want to find anything out, [come chat with us on Slack](https://digitaloxford.slack.com) (Sign up [here](https://digitaloxford.herokuapp.com)).
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 jsoxford.github.com
 ===================
 
-[![Slack Status](https://jsoxford.herokuapp.com/badge.svg)](https://jsoxford.herokuapp.com) [![Build Status](https://travis-ci.org/jsoxford/jsoxford.github.com.svg?branch=develop)](https://travis-ci.org/jsoxford/jsoxford.github.com)
+[![Slack Status](https://digitaloxford.herokuapp.com/badge.svg)](https://digitaloxford.herokuapp.com) [![Build Status](https://travis-ci.org/jsoxford/jsoxford.github.com.svg?branch=develop)](https://travis-ci.org/jsoxford/jsoxford.github.com)
 
 This is the source for jsoxford.com - it’s a static site that is generated with [jekyll](http://jekyllrb.com/).
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -15,7 +15,7 @@
             <img src="/img/icons/twitter.svg" class="icon" title="Twitter icon" alt="Twitter icon" />
             <div>Twitter</div>
         </a>
-        <a href="https://jsoxford.herokuapp.com/">
+        <a href="https://digitaloxford.herokuapp.com/">
             <img src="/img/icons/slack.svg" class="icon" title="Slack icon" alt="Slack icon" />
             <div>Slack</div>
         </a>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -42,7 +42,7 @@
                   <a href="https://twitter.com/intent/user?screen_name=jsoxford">Twitter</a>
                 </li>
                 <li>
-                  <a href="https://jsoxford.herokuapp.com/">Chat</a>
+                  <a href="https://digitaloxford.herokuapp.com/">Chat</a>
                 </li>
                 <li>
                   <a href="https://www.youtube.com/channel/UCjXR8G5M-iwkHVF26AFFsCQ">YouTube</a>


### PR DESCRIPTION
While the jsoxford Slackin page in Heroku still works, it doesn't have the Code of Conduct check.

Hopefully I got all the occurrences!