### PR TITLE
Parse bad markup out of event.description

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -149,6 +149,9 @@
     var link = $('<a/>');
     var meetupImage = $('<img/>').attr('src', '/img/meetup.png').attr('alt', 'Meetup');
     var headingTitle = $('<div/>');
+    
+    // This is to stop one dodgy meetup event breaking everything
+    var eventDescription = event.description.replace('&lt;/a&gt;<p>&lt;a href="http://nodeschool.io/"&gt;', '');
 
     post.addClass('post');
     post.data('date', eventDate.getFullYear() + '-' + (eventDate.getMonth() < 9 ? '0' : '') + (eventDate.getMonth() + 1) + '-' + eventDate.getDate());
@@ -161,7 +164,7 @@
     heading.append(headingTitle);
     heading.append(buildPostInfo(event, isUpcoming));
     post.append(heading);
-    post.append(event.description);
+    post.append(eventDescription);
 
     return post;
   }


### PR DESCRIPTION
This is terrible because it's for a specific bad post from Meetup, but it should stop the JSOxford homepage breaking.

Maybe there's a better way...