### PR TITLE
Using Emojione library with unicode

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -72,6 +72,7 @@
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" defer></script>
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js" defer></script>
+    <script src="//cdn.jsdelivr.net/emojione/2.2.6/lib/js/emojione.min.js"></script>
     <script src="/js/script.js" defer></script>
     <script type="text/javascript" src="//platform.twitter.com/widgets.js" async></script>
     <script src="http://cdn.lanyrd.net/badges/embed-v1.min.js" async></script>

--- a/js/script.js
+++ b/js/script.js
@@ -95,10 +95,7 @@
   // Emoji titles
   $('.post-title a').each(function (i, e) {
     var element = $(e);
-    var oldValue = element.html();
-    var newValue = emojione.shortnameToUnicode(element.html());
-    console.log(oldValue + " -> " + newValue);
-    element.html(newValue);
+    element.html(emojione.shortnameToUnicode(element.html()));
   })
 
   function formatDate(date) {

--- a/js/script.js
+++ b/js/script.js
@@ -92,6 +92,15 @@
     },
   });
 
+  // Emoji titles
+  $('.post-title a').each(function (i, e) {
+    var element = $(e);
+    var oldValue = element.html();
+    var newValue = emojione.shortnameToUnicode(element.html());
+    console.log(oldValue + " -> " + newValue);
+    element.html(newValue);
+  })
+
   function formatDate(date) {
     var dateString = '';
     dateString += date.getFullYear() + '-';


### PR DESCRIPTION
I originally made my Imojify library to solve the problem of colour emoji in Windows browsers.

About a year has passed, and what is still a VERY broken library is kind of useless - especially since Chrome on Windows 10 displays unicode emoji in colour now anyway.

This change uses the EmojiOne library to take the colon-notation emoji such as `:loudspeaker:` and turn it into the unicode character 📢 . The extra js file to download is quite big uncompressed, but it gzips very well (210KB -> 36KB).
